### PR TITLE
Rolle apt_proxy bei acng integriert

### DIFF
--- a/ansible/playbooks/configure_apt_proxy.yml
+++ b/ansible/playbooks/configure_apt_proxy.yml
@@ -1,4 +1,0 @@
----
-  - hosts: acng
-    roles:
-      - set_apt_proxy

--- a/ansible/playbooks/install_acng_server.yml
+++ b/ansible/playbooks/install_acng_server.yml
@@ -1,4 +1,5 @@
 ---
   - hosts: acng
     roles:
+      - { role: set_apt_proxy, tags: "proxy", become: yes}
       - { role: mgrote.acng, tags: "acng-server", become: yes}


### PR DESCRIPTION
entfällt als eigenständige Rolle da nur ACNG selber ins Netz muss.
Löst #103 