### PR TITLE
ansible: rolle: qemu-guest-agent

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -34,7 +34,6 @@
     - smartmontools
     - lm-sensors
   programs_only_vms:
-    - qemu-guest-agent
     - open-vm-tools
 
   ### oefenweb.ufw

--- a/ansible/playbooks/base/0_bootstrap.yml
+++ b/ansible/playbooks/base/0_bootstrap.yml
@@ -14,11 +14,6 @@
 #      - { role: mgrote.set_apt_sources, tags: "sources", become: yes}
       - { role: robertdebock.bootstrap, tags: "bootstrap", become: yes}
       - { role: ryandaniels.create_users, tags: "user", become: yes}
-    post_tasks:
-      - name: reboot für qemu-guest-agent (dauert bis zu 2min!)
-        become: true
-        reboot:
-          reboot_timeout: 120
     vars:
       ### reobertdebock.bootstrap
       bootstrap_user: user

--- a/ansible/playbooks/base/3_qemu_guest_agent.yml
+++ b/ansible/playbooks/base/3_qemu_guest_agent.yml
@@ -1,0 +1,4 @@
+---
+  - hosts: all
+    roles:
+      - { role: mgrote.qemu_guest_agent }

--- a/ansible/playbooks/base/99_base.yml
+++ b/ansible/playbooks/base/99_base.yml
@@ -2,5 +2,6 @@
   - import_playbook: 1_create_users.yml
   - import_playbook: 2_sources.yml
   - import_playbook: 2_packages.yml
+  - import_playbook: 3_qemu_guest_agent.yml
   - import_playbook: configure_ntp_client.yml
   - import_playbook: 3_haertung.yml

--- a/ansible/roles/mgrote.qemu_guest_agent/README.md
+++ b/ansible/roles/mgrote.qemu_guest_agent/README.md
@@ -1,0 +1,9 @@
+## mgrote.qemu_guest_agent
+
+### Beschreibung
+Installiert den qemu-guest-agent und startet die VM danach neu.
+Wird nur in VMs ausgeführt.
+
+### Funktioniert auf
+- [x] Ubuntu (>=18.04)
+- [x] Debian

--- a/ansible/roles/mgrote.qemu_guest_agent/handlers/main.yml
+++ b/ansible/roles/mgrote.qemu_guest_agent/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+  - name: reboot
+    become: true
+    reboot:
+      reboot_timeout: 120

--- a/ansible/roles/mgrote.qemu_guest_agent/tasks/main.yml
+++ b/ansible/roles/mgrote.qemu_guest_agent/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+  - name: install packages
+    become: yes
+    ansible.builtin.package:
+      name: qemu-guest-agent
+      state: present
+    when: ansible_virtualization_role == 'guest'
+    register: qemu_installed
+
+  - name: reboot (dauert bis zu 2min!)
+    become: true
+    reboot:
+      reboot_timeout: 120
+    when: qemu_installed.changed == true

--- a/ansible/roles/mgrote.qemu_guest_agent/tasks/main.yml
+++ b/ansible/roles/mgrote.qemu_guest_agent/tasks/main.yml
@@ -5,10 +5,4 @@
       name: qemu-guest-agent
       state: present
     when: ansible_virtualization_role == 'guest'
-    register: qemu_installed
-
-  - name: reboot (dauert bis zu 2min!)
-    become: true
-    reboot:
-      reboot_timeout: 120
-    when: qemu_installed.changed == true
+    notify: reboot


### PR DESCRIPTION
qemu-guest-agent als eigene rolle und an richtiger stelle eingesetzt
Bisher haben wir zwar die vm extra fur den agenten neugestartet, aber der war noch nicht installiert...